### PR TITLE
Bump version, add suspend, add clusterip

### DIFF
--- a/charts/vllm-gpu/Chart.yaml
+++ b/charts/vllm-gpu/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.7"
+appVersion: "0.8.2"

--- a/charts/vllm-gpu/templates/deployment.yaml
+++ b/charts/vllm-gpu/templates/deployment.yaml
@@ -3,7 +3,11 @@ kind: Deployment
 metadata:
   name: {{ include "llm-serving.fullname" . }}
 spec:
+  {{- if .Values.global.suspend }}
+  replicas: 0
+  {{- else }}
   replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       {{- include "llm-serving.selectorLabels" . | nindent 6 }}

--- a/charts/vllm-gpu/templates/ingress.yaml
+++ b/charts/vllm-gpu/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.enabled -}}
+{{- if not .Values.global.suspend }}
 {{/*
   These two are defined as such because calling . within a range loop
   is shortcut for path (see https://stackoverflow.com/questions/72484286/ingress-variables-syntax-from-values-yaml)
@@ -52,4 +53,5 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
+{{- end}}
 {{- end}}

--- a/charts/vllm-gpu/templates/service.yaml
+++ b/charts/vllm-gpu/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.suspend }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -5,10 +6,14 @@ metadata:
   labels:
      {{- include "llm-serving.labels" . | nindent 4 }}
 spec:
+  type: {{ .Values.service.type }}
   selector:
     {{- include "llm-serving.selectorLabels" . | nindent 4 }}
   ports:
   - port: {{ .Values.networking.port.number }}
     protocol: TCP
-    nodePort: {{ .Values.networking.port.nodePort }}
-  type: NodePort
+    targetPort: {{ .Values.networking.port.number }}
+    {{- if .Values.service.nodePort }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end}}
+{{- end}}

--- a/charts/vllm-gpu/values.yaml
+++ b/charts/vllm-gpu/values.yaml
@@ -1,10 +1,15 @@
+global:
+  suspend: false # Allow scaling the app to 0
+
 nameOverride: ""
 fullnameOverride: "llm-serving"
 podAnnotations: {}
 
 service:
+  type: ClusterIP
+  nodePort:
   image:
-    version: "vllm/vllm-openai:v0.7.0"
+    version: "vllm/vllm-openai:v0.8.2"
     pullPolicy: IfNotPresent
     custom:
       enabled: false
@@ -15,7 +20,7 @@ resources:
     gpu:
       number: 1
 
-huggingFace: 
+huggingFace:
   hfToken: ""
 
 llm:
@@ -30,11 +35,11 @@ networking:
     number: 8000
 
 ingress:
-    enabled: true
-    className: ""
-    annotations: 
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    hostname: "chart-example.local"
+  enabled: true
+  className: ""
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+  hostname: "chart-example.local"
 
 s3:
   enabled: true # Set to true to use S3


### PR DESCRIPTION
This PR does the following :  
* Bump `vllm-openai` version to `v0.8.2`  
* Add `global.suspend` (useful in Onyxia context) to easily scale down the helm install  
* :warning: Set service type to `ClusterIP` by default instead of `NodePort` (which can and should be enabled explicitly instead of being default). This can be considered as a breaking change :warning:    

Feel free to amend this PR if needed.  
Let me know if this needs more work before merge