### PR TITLE
[vllm-gpu] modify command args

### DIFF
--- a/charts/vllm-gpu/Chart.yaml
+++ b/charts/vllm-gpu/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/vllm-gpu/templates/deployment.yaml
+++ b/charts/vllm-gpu/templates/deployment.yaml
@@ -40,17 +40,8 @@ spec:
         {{- else }}
         - {{ .Values.llm.hfModelName }}
         {{- end }}
-        {{- if hasKey .Values.llm "memoryUtilization" }}
-        - --gpu-memory-utilization
-        - "{{ .Values.llm.memoryUtilization }}"
-        {{- end }}
-        {{- if hasKey .Values.llm "dtype" }}
-        - --dtype
-        - "{{ .Values.llm.dtype }}"
-        {{- end }}
-        {{- if hasKey .Values.llm "maxModelLen" }}
-        - --max-model-len
-        - "{{ .Values.llm.maxModelLen }}"
+        {{- range $arg := splitList " " .Values.llm.args }}
+        - {{ $arg }}
         {{- end }}
         volumeMounts:
         - mountPath: /dev/shm

--- a/charts/vllm-gpu/values.yaml
+++ b/charts/vllm-gpu/values.yaml
@@ -21,9 +21,7 @@ huggingFace:
 llm:
   hfModelName: meta-llama/Llama-3.2-1B-Instruct
   localPath: "/root/.cache/huggingface"
-  memoryUtilization: 0.8
-  dtype: "half"
-  maxModelLen": 8208
+  args: '--gpu-memory-utilization "0.8" --dtype "half" --max-model-len "8200"'
 
 networking:
   port:


### PR DESCRIPTION
Previously, command-line arguments like `--gpu-memory-utilization`, `--dtype`, and `--max-model-len`
were passed as individual Helm values, making the template rigid and harder to maintain.

This change introduces a single `.Values.llm.args` string (space-separated), which is split and
iterated over to populate the command array. 

⚠️   consumers of the chart should now provide a single `args` string instead of separate fields.

Let me know if this needs more work before merge